### PR TITLE
WIP: Generalized atmosphere model uniform

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wgsl
@@ -32,9 +32,7 @@ fn main(@builtin(global_invocation_id) idx: vec3<u32>) {
 
     for (var slice_i: u32 = 0; slice_i < settings.aerial_view_lut_size.z; slice_i++) {
         for (var step_i: u32 = 0; step_i < settings.aerial_view_lut_samples; step_i++) {
-            let sample_i = f32(slice_i * settings.aerial_view_lut_samples + step_i);
-            let total_samples = f32(settings.aerial_view_lut_size.z * settings.aerial_view_lut_samples);
-            let t_i = t_max * (sample_i + 0.5) / total_samples;
+            let t_i = t_max * (f32(slice_i) + ((f32(step_i) + 0.5) / f32(settings.aerial_view_lut_samples))) / f32(settings.aerial_view_lut_size.z);
             let dt = (t_i - prev_t);
             prev_t = t_i;
 
@@ -59,6 +57,8 @@ fn main(@builtin(global_invocation_id) idx: vec3<u32>) {
         }
         //We only have one channel to store transmittance, so we store the mean
         let mean_transmittance = (throughput.r + throughput.g + throughput.b) / 3.0;
-        textureStore(aerial_view_lut_out, vec3(vec2<u32>(idx.xy), slice_i), vec4(total_inscattering, mean_transmittance));
+        let optical_depth = -log(max(mean_transmittance, 1e-6));
+        let log_inscattering = log(max(total_inscattering, vec3(1e-6)));
+        textureStore(aerial_view_lut_out, vec3(vec2<u32>(idx.xy), slice_i), vec4(log_inscattering, optical_depth));
     }
 }

--- a/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wgsl
@@ -32,7 +32,9 @@ fn main(@builtin(global_invocation_id) idx: vec3<u32>) {
 
     for (var slice_i: u32 = 0; slice_i < settings.aerial_view_lut_size.z; slice_i++) {
         for (var step_i: u32 = 0; step_i < settings.aerial_view_lut_samples; step_i++) {
-            let t_i = t_max * (f32(slice_i) + ((f32(step_i) + 0.5) / f32(settings.aerial_view_lut_samples))) / f32(settings.aerial_view_lut_size.z);
+            let sample_i = f32(slice_i * settings.aerial_view_lut_samples + step_i);
+            let total_samples = f32(settings.aerial_view_lut_size.z * settings.aerial_view_lut_samples);
+            let t_i = t_max * (sample_i + 0.5) / total_samples;
             let dt = (t_i - prev_t);
             prev_t = t_i;
 

--- a/crates/bevy_pbr/src/atmosphere/bindings.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/bindings.wgsl
@@ -4,10 +4,10 @@
 
 #import bevy_pbr::{
     mesh_view_types::Lights,
-    atmosphere::types::{Atmosphere, AtmosphereSettings, AtmosphereTransforms}
+    atmosphere::types::{AtmosphereUniforms, AtmosphereSettings, AtmosphereTransforms}
 }
 
-@group(0) @binding(0) var<uniform> atmosphere: Atmosphere;
+@group(0) @binding(0) var<uniform> atmosphere: AtmosphereUniforms;
 @group(0) @binding(1) var<uniform> settings: AtmosphereSettings;
 @group(0) @binding(2) var<uniform> atmosphere_transforms: AtmosphereTransforms;
 @group(0) @binding(3) var<uniform> view: View;

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -337,8 +337,10 @@ fn get_density(medium: GpuMedium, altitude: f32) -> f32 {
         case 1u: { // Tent
             let center_altitude = medium.density_params.x;
             let half_width = medium.density_params.y * 0.5;
+            if (half_width <= 0.0) {
+                return 0.0;
+            }
             let exponent = medium.density_params.z;
-            
             let dist = abs(altitude - center_altitude);
             return pow(max(0.0, 1.0 - dist / half_width), exponent);
         }

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -334,18 +334,7 @@ fn get_density(medium: GpuMedium, altitude: f32) -> f32 {
             let scale_height = medium.density_params.x;
             return exp(-altitude / scale_height);
         }
-        case 1u: { // SplitExponential
-            let scale_height_lower = medium.density_params.x;
-            let center_altitude = medium.density_params.y;
-            let scale_height_upper = medium.density_params.z;
-            
-            if altitude < center_altitude {
-                return exp(-altitude / scale_height_lower);
-            } else {
-                return exp(-(altitude - center_altitude) / scale_height_upper);
-            }
-        }
-        case 2u: { // Tent
+        case 1u: { // Tent
             let center_altitude = medium.density_params.x;
             let half_width = medium.density_params.y * 0.5;
             let exponent = medium.density_params.z;
@@ -376,10 +365,11 @@ fn get_phase_function(medium: GpuMedium, cos_theta: f32) -> f32 {
         case 3u: { // DualLobe
             let g1 = medium.phase_params.x;
             let g2 = medium.phase_params.y;
+            let w = medium.phase_params.z;
             return mix(
                 henyey_greenstein(cos_theta, g1),
                 henyey_greenstein(cos_theta, g2),
-                0.5
+                w
             );
         }
         default: {

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -3,7 +3,7 @@
 #import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_atan2}
 
 #import bevy_pbr::atmosphere::{
-    types::{Atmosphere,Scatterer},
+    types::{Atmosphere,GpuMedium},
     bindings::{
         atmosphere, settings, view, lights, transmittance_lut, transmittance_lut_sampler, 
         multiscattering_lut, multiscattering_lut_sampler, sky_view_lut, sky_view_lut_sampler,
@@ -136,10 +136,35 @@ fn sample_aerial_view_lut(uv: vec2<f32>, depth: f32) -> vec4<f32> {
     return textureSampleLevel(aerial_view_lut, aerial_view_lut_sampler, uvw, 0.0);
 }
 
+// PHASE FUNCTIONS
+
+// -(L . V) == (L . -V). -V here is our ray direction, which points away from the view 
+// instead of towards it (which would be the *view direction*, V)
+
+// evaluates the rayleigh phase function, which describes the likelihood
+// of a rayleigh scattering event scattering light from the light direction towards the view
+fn rayleigh(neg_LdotV: f32) -> f32 {
+    return FRAC_3_16_PI * (1 + (neg_LdotV * neg_LdotV));
+}
+
+// evaluates the henyey-greenstein phase function, which describes the likelihood
+// of a mie scattering event scattering light from the light direction towards the view
+fn henyey_greenstein(neg_LdotV: f32, g: f32) -> f32 {
+    let denom = 1.0 + g * g - 2.0 * g * neg_LdotV;
+    return FRAC_4_PI * (1.0 - g * g) / (denom * sqrt(denom));
+}
+
+// evaluates the cornette-shanks phase function
+fn cornette_shanks(neg_LdotV: f32, g: f32) -> f32 {
+    let g2 = g * g;
+    let denom = 1.0 + g2 - 2.0 * g * neg_LdotV;
+    return (1.0 - g2) / (4.0 * PI * pow(1.0 + g2 - 2.0 * g * neg_LdotV, 1.5));
+}
+
 // ATMOSPHERE SAMPLING
 
 struct AtmosphereSample {
-    // Total scattering coefficient (sum of all scatterers)
+    // Total scattering coefficient (sum of scattering)
     scattering: vec3<f32>,
     // Total extinction coefficient (scattering + absorption)
     extinction: vec3<f32>,
@@ -154,9 +179,9 @@ fn sample_atmosphere(r: f32) -> AtmosphereSample {
     sample.scattering = vec3(0.0);
     sample.extinction = vec3(0.0);
     
-    // Sum contributions from all scatterers
+    // Sum contributions from all layers
     for (var i = 0u; i < 3u; i++) {
-        let s = atmosphere.scatterers[i];
+        let s = atmosphere.layers[i];
         let density = get_density(s, altitude);
         sample.scattering += density * s.scattering;
         sample.extinction += density * (s.scattering + s.absorption);
@@ -179,7 +204,7 @@ fn sample_local_inscattering(local_atmosphere: AtmosphereSample, ray_dir: vec3<f
         let altitude = local_r - atmosphere.bottom_radius;
         
         for (var i = 0u; i < 3u; i++) {
-            let s = atmosphere.scatterers[i];
+            let s = atmosphere.layers[i];
             let density = get_density(s, altitude);
             let phase = get_phase_function(s, neg_LdotV);
             total_scattering += density * s.scattering * phase;
@@ -302,39 +327,31 @@ fn zenith_azimuth_to_ray_dir(zenith: f32, azimuth: f32) -> vec3<f32> {
     return vec3(sin_azimuth * sin_zenith, mu, -cos_azimuth * sin_zenith);
 }
 
-fn get_density(s: Scatterer, altitude: f32) -> f32 {
-    switch s.density_profile.profile_type {
+fn get_density(medium: GpuMedium, altitude: f32) -> f32 {
+    let density_type = u32(medium.density_params.w);
+    switch density_type {
         case 0u: { // Exponential
-            return exp(-s.density_profile.scale * altitude);
+            let scale_height = medium.density_params.x;
+            return exp(-altitude / scale_height);
         }
-        case 1u: { // Split exponential
-            if (altitude < s.density_profile.split_altitude) {
-                return exp(-s.density_profile.scale * altitude);
+        case 1u: { // SplitExponential
+            let scale_height_lower = medium.density_params.x;
+            let center_altitude = medium.density_params.y;
+            let scale_height_upper = medium.density_params.z;
+            
+            if altitude < center_altitude {
+                return exp(-altitude / scale_height_lower);
             } else {
-                let h = altitude - s.density_profile.split_altitude;
-                return exp(-s.density_profile.scale * s.density_profile.split_altitude) 
-                     * exp(-s.density_profile.scale_high * h);
+                return exp(-(altitude - center_altitude) / scale_height_upper);
             }
         }
-        case 2u: { // Piecewise linear
-            for (var i = 0u; i < s.density_profile.num_points - 1u; i++) {
-                let vec_idx = i / 2u;
-                let pair_idx = i % 2u;
-                
-                let point = s.density_profile.control_points[vec_idx].altitude_density;
-                let next_point = s.density_profile.control_points[vec_idx + 1u].altitude_density;
-                
-                let alt1 = select(point.x, point.z, pair_idx == 1u);
-                let den1 = select(point.y, point.w, pair_idx == 1u);
-                let alt2 = select(next_point.x, next_point.z, pair_idx == 1u);
-                let den2 = select(next_point.y, next_point.w, pair_idx == 1u);
-                
-                if (altitude >= alt1 && altitude <= alt2) {
-                    let t = (altitude - alt1) / (alt2 - alt1);
-                    return mix(den1, den2, t);
-                }
-            }
-            return 0.0;
+        case 2u: { // Tent
+            let center_altitude = medium.density_params.x;
+            let half_width = medium.density_params.y * 0.5;
+            let exponent = medium.density_params.z;
+            
+            let dist = abs(altitude - center_altitude);
+            return pow(max(0.0, 1.0 - dist / half_width), exponent);
         }
         default: {
             return 0.0;
@@ -342,14 +359,31 @@ fn get_density(s: Scatterer, altitude: f32) -> f32 {
     }
 }
 
-fn get_phase_function(s: Scatterer, cos_theta: f32) -> f32 {
-    if (s.asymmetry == 0.0) {
-        // Rayleigh phase function
-        return 3.0 / (16.0 * PI) * (1.0 + cos_theta * cos_theta);
-    } else {
-        // Mie phase function (Cornette-Shanks)
-        let g = s.asymmetry;
-        let g2 = g * g;
-        return (1.0 - g2) / (4.0 * PI * pow(1.0 + g2 - 2.0 * g * cos_theta, 1.5));
+fn get_phase_function(medium: GpuMedium, cos_theta: f32) -> f32 {
+    let phase_type = u32(medium.phase_params.w);
+    switch phase_type {
+        case 0u: { // Rayleigh
+            return rayleigh(cos_theta);
+        }
+        case 1u: { // HenyeyGreenstein
+            let g = medium.phase_params.x;
+            return henyey_greenstein(cos_theta, g);
+        }
+        case 2u: { // CornetteShanks
+            let g = medium.phase_params.x;
+            return cornette_shanks(cos_theta, g);
+        }
+        case 3u: { // DualLobe
+            let g1 = medium.phase_params.x;
+            let g2 = medium.phase_params.y;
+            return mix(
+                henyey_greenstein(cos_theta, g1),
+                henyey_greenstein(cos_theta, g2),
+                0.5
+            );
+        }
+        default: {
+            return 0.0;
+        }
     }
 }

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -3,7 +3,7 @@
 #import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_atan2}
 
 #import bevy_pbr::atmosphere::{
-    types::Atmosphere,
+    types::{Atmosphere,Scatterer},
     bindings::{
         atmosphere, settings, view, lights, transmittance_lut, transmittance_lut_sampler, 
         multiscattering_lut, multiscattering_lut_sampler, sky_view_lut, sky_view_lut_sampler,
@@ -136,100 +136,69 @@ fn sample_aerial_view_lut(uv: vec2<f32>, depth: f32) -> vec4<f32> {
     return textureSampleLevel(aerial_view_lut, aerial_view_lut_sampler, uvw, 0.0);
 }
 
-// PHASE FUNCTIONS
-
-// -(L . V) == (L . -V). -V here is our ray direction, which points away from the view 
-// instead of towards it (which would be the *view direction*, V)
-
-// evaluates the rayleigh phase function, which describes the likelihood
-// of a rayleigh scattering event scattering light from the light direction towards the view
-fn rayleigh(neg_LdotV: f32) -> f32 {
-    return FRAC_3_16_PI * (1 + (neg_LdotV * neg_LdotV));
-}
-
-// evaluates the henyey-greenstein phase function, which describes the likelihood
-// of a mie scattering event scattering light from the light direction towards the view
-fn henyey_greenstein(neg_LdotV: f32) -> f32 {
-    let g = atmosphere.mie_asymmetry;
-    let denom = 1.0 + g * g - 2.0 * g * neg_LdotV;
-    return FRAC_4_PI * (1.0 - g * g) / (denom * sqrt(denom));
-}
-
 // ATMOSPHERE SAMPLING
 
 struct AtmosphereSample {
-    /// units: m^-1
-    rayleigh_scattering: vec3<f32>,
-
-    /// units: m^-1
-    mie_scattering: f32,
-
-    /// the sum of scattering and absorption. Since the phase function doesn't
-    /// matter for this, we combine rayleigh and mie extinction to a single 
-    //  value.
-    //
-    /// units: m^-1
-    extinction: vec3<f32>
+    // Total scattering coefficient (sum of all scatterers)
+    scattering: vec3<f32>,
+    // Total extinction coefficient (scattering + absorption)
+    extinction: vec3<f32>,
 }
 
 /// Samples atmosphere optical densities at a given radius
 fn sample_atmosphere(r: f32) -> AtmosphereSample {
-    let altitude = clamp(r, atmosphere.bottom_radius, atmosphere.top_radius) - atmosphere.bottom_radius;
-
-    // atmosphere values at altitude
-    let mie_density = exp(-atmosphere.mie_density_exp_scale * altitude);
-    let rayleigh_density = exp(-atmosphere.rayleigh_density_exp_scale * altitude);
-    var ozone_density: f32 = max(0.0, 1.0 - (abs(altitude - atmosphere.ozone_layer_altitude) / (atmosphere.ozone_layer_width * 0.5)));
-
-    let mie_scattering = mie_density * atmosphere.mie_scattering;
-    let mie_absorption = mie_density * atmosphere.mie_absorption;
-    let mie_extinction = mie_scattering + mie_absorption;
-
-    let rayleigh_scattering = rayleigh_density * atmosphere.rayleigh_scattering;
-    // no rayleigh absorption
-    // rayleigh extinction is the sum of scattering and absorption
-
-    // ozone doesn't contribute to scattering
-    let ozone_absorption = ozone_density * atmosphere.ozone_absorption;
-
+    let altitude = r - atmosphere.bottom_radius;
     var sample: AtmosphereSample;
-    sample.rayleigh_scattering = rayleigh_scattering;
-    sample.mie_scattering = mie_scattering;
-    sample.extinction = rayleigh_scattering + mie_extinction + ozone_absorption;
-
+    
+    // Initialize with zeros
+    sample.scattering = vec3(0.0);
+    sample.extinction = vec3(0.0);
+    
+    // Sum contributions from all scatterers
+    for (var i = 0u; i < 3u; i++) {
+        let s = atmosphere.scatterers[i];
+        let density = get_density(s, altitude);
+        sample.scattering += density * s.scattering;
+        sample.extinction += density * (s.scattering + s.absorption);
+    }
+    
     return sample;
 }
 
 /// evaluates L_scat, equation 3 in the paper, which gives the total single-order scattering towards the view at a single point
 fn sample_local_inscattering(local_atmosphere: AtmosphereSample, ray_dir: vec3<f32>, local_r: f32, local_up: vec3<f32>) -> vec3<f32> {
     var inscattering = vec3(0.0);
+    
     for (var light_i: u32 = 0u; light_i < lights.n_directional_lights; light_i++) {
         let light = &lights.directional_lights[light_i];
-
         let mu_light = dot((*light).direction_to_light, local_up);
-
-        // -(L . V) == (L . -V). -V here is our ray direction, which points away from the view
-        // instead of towards it (as is the convention for V)
         let neg_LdotV = dot((*light).direction_to_light, ray_dir);
-
-        // Phase functions give the proportion of light
-        // scattered towards the camera for each scattering type
-        let rayleigh_phase = rayleigh(neg_LdotV);
-        let mie_phase = henyey_greenstein(neg_LdotV);
-        let scattering_coeff = local_atmosphere.rayleigh_scattering * rayleigh_phase + local_atmosphere.mie_scattering * mie_phase;
+        
+        // Calculate total scattering coefficient including phase function
+        var total_scattering = vec3(0.0);
+        let altitude = local_r - atmosphere.bottom_radius;
+        
+        for (var i = 0u; i < 3u; i++) {
+            let s = atmosphere.scatterers[i];
+            let density = get_density(s, altitude);
+            let phase = get_phase_function(s, neg_LdotV);
+            total_scattering += density * s.scattering * phase;
+        }
 
         let transmittance_to_light = sample_transmittance_lut(local_r, mu_light);
         let shadow_factor = transmittance_to_light * f32(!ray_intersects_ground(local_r, mu_light));
-
-        // Transmittance from scattering event to light source
-        let scattering_factor = shadow_factor * scattering_coeff;
-
-        // Additive factor from the multiscattering LUT
+        
+        // Single scattering
+        let scattering_factor = shadow_factor * total_scattering;
+        
+        // Multiple scattering
+        // Note: local_atmosphere.scattering already includes density
         let psi_ms = sample_multiscattering_lut(local_r, mu_light);
-        let multiscattering_factor = psi_ms * (local_atmosphere.rayleigh_scattering + local_atmosphere.mie_scattering);
-
+        let multiscattering_factor = psi_ms * local_atmosphere.scattering;
+        
         inscattering += (*light).color.rgb * (scattering_factor + multiscattering_factor);
     }
+    
     return inscattering * view.exposure;
 }
 
@@ -331,4 +300,56 @@ fn zenith_azimuth_to_ray_dir(zenith: f32, azimuth: f32) -> vec3<f32> {
     let sin_azimuth = sin(azimuth);
     let cos_azimuth = cos(azimuth);
     return vec3(sin_azimuth * sin_zenith, mu, -cos_azimuth * sin_zenith);
+}
+
+fn get_density(s: Scatterer, altitude: f32) -> f32 {
+    switch s.density_profile.profile_type {
+        case 0u: { // Exponential
+            return exp(-s.density_profile.scale * altitude);
+        }
+        case 1u: { // Split exponential
+            if (altitude < s.density_profile.split_altitude) {
+                return exp(-s.density_profile.scale * altitude);
+            } else {
+                let h = altitude - s.density_profile.split_altitude;
+                return exp(-s.density_profile.scale * s.density_profile.split_altitude) 
+                     * exp(-s.density_profile.scale_high * h);
+            }
+        }
+        case 2u: { // Piecewise linear
+            for (var i = 0u; i < s.density_profile.num_points - 1u; i++) {
+                let vec_idx = i / 2u;
+                let pair_idx = i % 2u;
+                
+                let point = s.density_profile.control_points[vec_idx].altitude_density;
+                let next_point = s.density_profile.control_points[vec_idx + 1u].altitude_density;
+                
+                let alt1 = select(point.x, point.z, pair_idx == 1u);
+                let den1 = select(point.y, point.w, pair_idx == 1u);
+                let alt2 = select(next_point.x, next_point.z, pair_idx == 1u);
+                let den2 = select(next_point.y, next_point.w, pair_idx == 1u);
+                
+                if (altitude >= alt1 && altitude <= alt2) {
+                    let t = (altitude - alt1) / (alt2 - alt1);
+                    return mix(den1, den2, t);
+                }
+            }
+            return 0.0;
+        }
+        default: {
+            return 0.0;
+        }
+    }
+}
+
+fn get_phase_function(s: Scatterer, cos_theta: f32) -> f32 {
+    if (s.asymmetry == 0.0) {
+        // Rayleigh phase function
+        return 3.0 / (16.0 * PI) * (1.0 + cos_theta * cos_theta);
+    } else {
+        // Mie phase function (Cornette-Shanks)
+        let g = s.asymmetry;
+        let g2 = g * g;
+        return (1.0 - g2) / (4.0 * PI * pow(1.0 + g2 - 2.0 * g * cos_theta, 1.5));
+    }
 }

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -299,7 +299,11 @@ impl Medium {
     pub const EMPTY: Self = Self {
         scattering: Vec3::ZERO,
         absorption: Vec3::ZERO,
-        density_profile: DensityProfile::Exponential { scale_height: 1.0 },
+        density_profile: DensityProfile::Tent {
+            center_altitude: 0.0,
+            layer_width: 0.0,
+            exponent: 1.0,
+        },
         phase_function: PhaseFunction::Rayleigh,
     };
 }

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -237,25 +237,6 @@ pub enum DensityProfile {
         /// units: m
         scale_height: f32,
     },
-    /// Split exponential density profile
-    SplitExponential {
-        /// The rate of falloff of particulate with respect to altitude
-        /// below the center altitude.
-        ///
-        /// units: m
-        scale_height_lower: f32,
-
-        /// The altitude at which the density profile changes.
-        ///
-        /// units: m
-        center_altitude: f32,
-
-        /// The rate of falloff of particulate with respect to altitude
-        /// above the center altitude.
-        ///
-        /// units: m
-        scale_height_upper: f32,
-    },
     /// Tent-shaped density profile using absolute distance from the center altitude.
     Tent {
         /// The altitude at which the density profile reaches its maximum.
@@ -285,10 +266,11 @@ pub enum PhaseFunction {
     /// Henyey-Greenstein phase function for aerosols
     HenyeyGreenstein(f32),
     /// Cornette-Shanks phase function for aerosols improved over Henyey-Greenstein
+    /// also known as Schlick phase function
     CornetteShanks(f32),
     /// Dual Lobe phase function used for simulating backscattering
     /// in water vapor in clouds or ice crystals.
-    DualLobe(f32, f32),
+    DualLobe(f32, f32, f32),
 }
 
 /// CPU representation of a medium or particulate that interacts with light
@@ -313,6 +295,15 @@ pub struct Medium {
     pub phase_function: PhaseFunction,
 }
 
+impl Medium {
+    pub const EMPTY: Self = Self {
+        scattering: Vec3::ZERO,
+        absorption: Vec3::ZERO,
+        density_profile: DensityProfile::Exponential { scale_height: 1.0 },
+        phase_function: PhaseFunction::Rayleigh,
+    };
+}
+
 /// GPU representation of a medium
 #[derive(Clone, ShaderType)]
 pub struct GpuMedium {
@@ -326,23 +317,18 @@ impl From<Medium> for GpuMedium {
     fn from(medium: Medium) -> Self {
         let density_params = match medium.density_profile {
             DensityProfile::Exponential { scale_height } => Vec4::new(scale_height, 0.0, 0.0, 0.0),
-            DensityProfile::SplitExponential {
-                scale_height_lower,
-                center_altitude,
-                scale_height_upper,
-            } => Vec4::new(scale_height_lower, center_altitude, scale_height_upper, 1.0),
             DensityProfile::Tent {
                 center_altitude,
                 layer_width,
                 exponent,
-            } => Vec4::new(center_altitude, layer_width, exponent, 2.0),
+            } => Vec4::new(center_altitude, layer_width, exponent, 1.0),
         };
 
         let phase_params = match medium.phase_function {
             PhaseFunction::Rayleigh => Vec4::ZERO,
             PhaseFunction::HenyeyGreenstein(g) => Vec4::new(g, 0.0, 0.0, 1.0),
             PhaseFunction::CornetteShanks(g) => Vec4::new(g, 0.0, 0.0, 2.0),
-            PhaseFunction::DualLobe(g1, g2) => Vec4::new(g1, g2, 0.0, 3.0),
+            PhaseFunction::DualLobe(g1, g2, w) => Vec4::new(g1, g2, w, 3.0),
         };
 
         Self {
@@ -438,7 +424,7 @@ impl Atmosphere {
                 density_profile: DensityProfile::Exponential {
                     scale_height: 1_200.0,
                 },
-                phase_function: PhaseFunction::HenyeyGreenstein(0.8),
+                phase_function: PhaseFunction::CornetteShanks(0.8),
             },
             // Ozone layer
             Medium {
@@ -451,6 +437,34 @@ impl Atmosphere {
                 },
                 phase_function: PhaseFunction::Rayleigh,
             },
+        ],
+    };
+
+    pub const MARS: Self = Self {
+        bottom_radius: 3_389_500.0,
+        top_radius: 3_509_500.0,
+        ground_albedo: Vec3::splat(0.1),
+        layers: [
+            // CO2 (primary atmospheric component on Mars)
+            Medium {
+                scattering: Vec3::new(0.019918e-03, 0.01357e-03, 0.00575e-03),
+                absorption: Vec3::ZERO,
+                density_profile: DensityProfile::Exponential {
+                    scale_height: 10_430.0,
+                },
+                phase_function: PhaseFunction::Rayleigh,
+            },
+            // Dust (Martian aerosols)
+            Medium {
+                scattering: Vec3::splat(5.361771e-05),
+                absorption: Vec3::splat(5.530838e-07),
+                density_profile: DensityProfile::Exponential {
+                    scale_height: 3_095.0,
+                },
+                phase_function: PhaseFunction::CornetteShanks(0.85),
+            },
+            // Empty third layer (Mars has no ozone layer)
+            Medium::EMPTY,
         ],
     };
 

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -41,7 +41,7 @@ use bevy_ecs::{
     schedule::IntoSystemConfigs,
     system::{lifetimeless::Read, Query},
 };
-use bevy_math::{UVec2, UVec3, Vec3};
+use bevy_math::{UVec2, UVec3, Vec3, Vec4};
 use bevy_reflect::Reflect;
 use bevy_render::{
     extract_component::UniformComponentPlugin,
@@ -244,8 +244,65 @@ impl Plugin for AtmospherePlugin {
 /// participating in Rayleigh and Mie scattering falls off roughly exponentially
 /// from the planet's surface, ozone only exists in a band centered at a fairly
 /// high altitude.
+// Add this new enum to define different density function types
 #[derive(Clone, Component, Reflect, ShaderType)]
-#[require(AtmosphereSettings)]
+pub struct ControlPoint {
+    altitude_density: Vec4, // Pack two (altitude, density) pairs per vec4
+}
+
+impl ControlPoint {
+    pub const ZERO: Self = Self {
+        altitude_density: Vec4::ZERO,
+    };
+
+    pub const fn new(altitude: f32, density: f32) -> Self {
+        Self {
+            altitude_density: Vec4::new(altitude, density, 0.0, 0.0),
+        }
+    }
+}
+
+#[derive(Clone, Component, Reflect, ShaderType)]
+pub struct DensityProfile {
+    profile_type: u32,
+    scale: f32,                        // For exponential profiles
+    scale_high: f32,                   // For split exponential
+    split_altitude: f32,               // For split exponential
+    control_points: [ControlPoint; 6], // Up to 6 points
+    num_points: u32,                   // Number of active control points
+}
+
+impl DensityProfile {
+    pub const ZERO: Self = Self {
+        profile_type: 0,
+        scale: 0.0,
+        scale_high: 0.0,
+        split_altitude: 0.0,
+        control_points: [ControlPoint::ZERO; 6],
+        num_points: 0,
+    };
+}
+
+#[derive(Clone, Component, Reflect, ShaderType)]
+pub struct Scatterer {
+    pub density_profile: DensityProfile,
+    pub asymmetry: f32,
+
+    // Scattering properties
+    pub scattering: Vec3,
+    pub absorption: Vec3,
+}
+
+impl Scatterer {
+    pub const ZERO: Self = Self {
+        density_profile: DensityProfile::ZERO,
+        asymmetry: 0.0,
+        scattering: Vec3::ZERO,
+        absorption: Vec3::ZERO,
+    };
+}
+
+#[derive(Clone, Component, Reflect, ShaderType)]
 pub struct Atmosphere {
     /// Radius of the planet
     ///
@@ -264,62 +321,12 @@ pub struct Atmosphere {
     /// units: N/A
     pub ground_albedo: Vec3,
 
-    /// The rate of falloff of rayleigh particulate with respect to altitude:
-    /// optical density = exp(-rayleigh_density_exp_scale * altitude in meters).
+    /// An array of scatterers, which describe the atmosphere.
     ///
-    /// THIS VALUE MUST BE POSITIVE
-    ///
-    /// units: N/A
-    pub rayleigh_density_exp_scale: f32,
-
-    /// The scattering optical density of rayleigh particulate, or how
-    /// much light it scatters per meter
-    ///
-    /// units: m^-1
-    pub rayleigh_scattering: Vec3,
-
-    /// The rate of falloff of mie particulate with respect to altitude:
-    /// optical density = exp(-mie_density_exp_scale * altitude in meters)
-    ///
-    /// THIS VALUE MUST BE POSITIVE
-    ///
-    /// units: N/A
-    pub mie_density_exp_scale: f32,
-
-    /// The scattering optical density of mie particulate, or how much light
-    /// it scatters per meter.
-    ///
-    /// units: m^-1
-    pub mie_scattering: f32,
-
-    /// The absorbing optical density of mie particulate, or how much light
-    /// it absorbs per meter.
-    ///
-    /// units: m^-1
-    pub mie_absorption: f32,
-
-    /// The "asymmetry" of mie scattering, or how much light tends to scatter
-    /// forwards, rather than backwards or to the side.
-    ///
-    /// domain: (-1, 1)
-    /// units: N/A
-    pub mie_asymmetry: f32, //the "asymmetry" value of the phase function, unitless. Domain: (-1, 1)
-
-    /// The altitude at which the ozone layer is centered.
-    ///
-    /// units: m
-    pub ozone_layer_altitude: f32,
-
-    /// The width of the ozone layer
-    ///
-    /// units: m
-    pub ozone_layer_width: f32,
-
-    /// The optical density of ozone, or how much of each wavelength of
-    /// light it absorbs per meter.
-    ///
-    /// units: m^-1
-    pub ozone_absorption: Vec3,
+    /// First scatterer is typically Rayleigh (air/CO2)
+    /// Second scatterer is typically Mie (aerosols/dust)
+    /// Third scatterer is typically Ozone (absorption)
+    pub scatterers: [Scatterer; 3],
 }
 
 impl Atmosphere {
@@ -327,22 +334,57 @@ impl Atmosphere {
         bottom_radius: 6_360_000.0,
         top_radius: 6_460_000.0,
         ground_albedo: Vec3::splat(0.3),
-        rayleigh_density_exp_scale: 1.0 / 8_000.0,
-        rayleigh_scattering: Vec3::new(5.802e-6, 13.558e-6, 33.100e-6),
-        mie_density_exp_scale: 1.0 / 1_200.0,
-        mie_scattering: 3.996e-6,
-        mie_absorption: 0.444e-6,
-        mie_asymmetry: 0.8,
-        ozone_layer_altitude: 25_000.0,
-        ozone_layer_width: 30_000.0,
-        ozone_absorption: Vec3::new(0.650e-6, 1.881e-6, 0.085e-6),
+
+        scatterers: [
+            // Rayleigh scattering (air molecules)
+            Scatterer {
+                density_profile: DensityProfile {
+                    profile_type: 0,
+                    scale: 1.0 / 8_000.0,
+                    ..DensityProfile::ZERO
+                },
+                scattering: Vec3::new(5.802e-6, 13.558e-6, 33.100e-6),
+                absorption: Vec3::ZERO,
+                asymmetry: 0.0,
+            },
+            // Mie scattering (aerosols)
+            Scatterer {
+                density_profile: DensityProfile {
+                    profile_type: 0,
+                    scale: 1.0 / 1_200.0,
+                    ..DensityProfile::ZERO
+                },
+                scattering: Vec3::splat(3.996e-6),
+                absorption: Vec3::splat(0.444e-6),
+                asymmetry: 0.8,
+            },
+            // Ozone
+            Scatterer {
+                density_profile: DensityProfile {
+                    profile_type: 2,
+                    control_points: [
+                        ControlPoint::new(0.0, 0.022),
+                        ControlPoint::new(8_000.0, 0.0),
+                        ControlPoint::new(21_500.0, 1.0),
+                        ControlPoint::new(39_000.0, 0.034),
+                        ControlPoint::new(40_000.0, 0.0),
+                        ControlPoint::new(45_000.0, 0.0),
+                    ],
+                    num_points: 6,
+                    ..DensityProfile::ZERO
+                },
+                scattering: Vec3::ZERO,
+                absorption: Vec3::new(0.650e-6, 1.881e-6, 0.085e-6),
+                asymmetry: 0.0,
+            },
+        ],
     };
 
     pub fn with_density_multiplier(mut self, mult: f32) -> Self {
-        self.rayleigh_scattering *= mult;
-        self.mie_scattering *= mult;
-        self.mie_absorption *= mult;
-        self.ozone_absorption *= mult;
+        for scatterer in self.scatterers.iter_mut() {
+            scatterer.scattering *= mult;
+            scatterer.absorption *= mult;
+        }
         self
     }
 }

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -36,7 +36,7 @@ use bevy_app::{App, Plugin};
 use bevy_asset::load_internal_asset;
 use bevy_core_pipeline::core_3d::graph::Node3d;
 use bevy_ecs::{
-    component::{require, Component},
+    component::Component,
     query::{Changed, QueryItem, With},
     schedule::IntoSystemConfigs,
     system::{lifetimeless::Read, Query},
@@ -149,7 +149,7 @@ impl Plugin for AtmospherePlugin {
             .add_plugins((
                 ExtractComponentPlugin::<Atmosphere>::default(),
                 ExtractComponentPlugin::<AtmosphereSettings>::default(),
-                UniformComponentPlugin::<Atmosphere>::default(),
+                UniformComponentPlugin::<AtmosphereUniforms>::default(),
                 UniformComponentPlugin::<AtmosphereSettings>::default(),
             ));
     }
@@ -224,6 +224,136 @@ impl Plugin for AtmospherePlugin {
     }
 }
 
+/// The density profile describes how the density of a medium
+/// changes with respect to altitude.
+#[derive(Clone, Reflect)]
+pub enum DensityProfile {
+    /// Exponential density profile using a scale height.
+    Exponential {
+        /// The rate of falloff of particulate with respect to altitude:
+        /// optical density = exp(-altitude / scale_height). This value
+        /// must be positive.
+        ///
+        /// units: m
+        scale_height: f32,
+    },
+    /// Split exponential density profile
+    SplitExponential {
+        /// The rate of falloff of particulate with respect to altitude
+        /// below the center altitude.
+        ///
+        /// units: m
+        scale_height_lower: f32,
+
+        /// The altitude at which the density profile changes.
+        ///
+        /// units: m
+        center_altitude: f32,
+
+        /// The rate of falloff of particulate with respect to altitude
+        /// above the center altitude.
+        ///
+        /// units: m
+        scale_height_upper: f32,
+    },
+    /// Tent-shaped density profile using absolute distance from the center altitude.
+    Tent {
+        /// The altitude at which the density profile reaches its maximum.
+        ///
+        /// units: m
+        center_altitude: f32,
+
+        /// The width of the density profile at the center altitude.
+        ///
+        /// units: m
+        layer_width: f32,
+
+        /// The exponent of the density profile used to shape the density
+        /// profile.
+        ///
+        /// units: N/A
+        exponent: f32,
+    },
+}
+
+/// The phase function describes how light is scattered by a medium
+/// given the angle between the incoming and outgoing light.
+#[derive(Clone, Reflect)]
+pub enum PhaseFunction {
+    /// Rayleigh phase function for molecules
+    Rayleigh,
+    /// Henyey-Greenstein phase function for aerosols
+    HenyeyGreenstein(f32),
+    /// Cornette-Shanks phase function for aerosols improved over Henyey-Greenstein
+    CornetteShanks(f32),
+    /// Dual Lobe phase function used for simulating backscattering
+    /// in water vapor in clouds or ice crystals.
+    DualLobe(f32, f32),
+}
+
+/// CPU representation of a medium or particulate that interacts with light
+#[derive(Clone, Reflect)]
+pub struct Medium {
+    /// The scattering optical density of the particulate, or how much light
+    /// it scatters per meter.
+    ///
+    /// units: m^-1
+    pub scattering: Vec3,
+
+    /// The absorbing optical density of the particulate, or how much light
+    /// it absorbs per meter.
+    ///
+    /// units: m^-1
+    pub absorption: Vec3,
+
+    /// The density profile of the medium
+    pub density_profile: DensityProfile,
+
+    /// The phase function of the medium
+    pub phase_function: PhaseFunction,
+}
+
+/// GPU representation of a medium
+#[derive(Clone, ShaderType)]
+pub struct GpuMedium {
+    pub scattering: Vec3,
+    pub absorption: Vec3,
+    pub density_params: Vec4,
+    pub phase_params: Vec4,
+}
+
+impl From<Medium> for GpuMedium {
+    fn from(medium: Medium) -> Self {
+        let density_params = match medium.density_profile {
+            DensityProfile::Exponential { scale_height } => Vec4::new(scale_height, 0.0, 0.0, 0.0),
+            DensityProfile::SplitExponential {
+                scale_height_lower,
+                center_altitude,
+                scale_height_upper,
+            } => Vec4::new(scale_height_lower, center_altitude, scale_height_upper, 1.0),
+            DensityProfile::Tent {
+                center_altitude,
+                layer_width,
+                exponent,
+            } => Vec4::new(center_altitude, layer_width, exponent, 2.0),
+        };
+
+        let phase_params = match medium.phase_function {
+            PhaseFunction::Rayleigh => Vec4::ZERO,
+            PhaseFunction::HenyeyGreenstein(g) => Vec4::new(g, 0.0, 0.0, 1.0),
+            PhaseFunction::CornetteShanks(g) => Vec4::new(g, 0.0, 0.0, 2.0),
+            PhaseFunction::DualLobe(g1, g2) => Vec4::new(g1, g2, 0.0, 3.0),
+        };
+
+        Self {
+            scattering: medium.scattering,
+            absorption: medium.absorption,
+            density_params,
+            phase_params,
+        }
+    }
+}
+
 /// This component describes the atmosphere of a planet, and when added to a camera
 /// will enable atmospheric scattering for that camera. This is only compatible with
 /// HDR cameras.
@@ -244,65 +374,7 @@ impl Plugin for AtmospherePlugin {
 /// participating in Rayleigh and Mie scattering falls off roughly exponentially
 /// from the planet's surface, ozone only exists in a band centered at a fairly
 /// high altitude.
-// Add this new enum to define different density function types
-#[derive(Clone, Component, Reflect, ShaderType)]
-pub struct ControlPoint {
-    altitude_density: Vec4, // Pack two (altitude, density) pairs per vec4
-}
-
-impl ControlPoint {
-    pub const ZERO: Self = Self {
-        altitude_density: Vec4::ZERO,
-    };
-
-    pub const fn new(altitude: f32, density: f32) -> Self {
-        Self {
-            altitude_density: Vec4::new(altitude, density, 0.0, 0.0),
-        }
-    }
-}
-
-#[derive(Clone, Component, Reflect, ShaderType)]
-pub struct DensityProfile {
-    profile_type: u32,
-    scale: f32,                        // For exponential profiles
-    scale_high: f32,                   // For split exponential
-    split_altitude: f32,               // For split exponential
-    control_points: [ControlPoint; 6], // Up to 6 points
-    num_points: u32,                   // Number of active control points
-}
-
-impl DensityProfile {
-    pub const ZERO: Self = Self {
-        profile_type: 0,
-        scale: 0.0,
-        scale_high: 0.0,
-        split_altitude: 0.0,
-        control_points: [ControlPoint::ZERO; 6],
-        num_points: 0,
-    };
-}
-
-#[derive(Clone, Component, Reflect, ShaderType)]
-pub struct Scatterer {
-    pub density_profile: DensityProfile,
-    pub asymmetry: f32,
-
-    // Scattering properties
-    pub scattering: Vec3,
-    pub absorption: Vec3,
-}
-
-impl Scatterer {
-    pub const ZERO: Self = Self {
-        density_profile: DensityProfile::ZERO,
-        asymmetry: 0.0,
-        scattering: Vec3::ZERO,
-        absorption: Vec3::ZERO,
-    };
-}
-
-#[derive(Clone, Component, Reflect, ShaderType)]
+#[derive(Clone, Component, Reflect)]
 pub struct Atmosphere {
     /// Radius of the planet
     ///
@@ -321,69 +393,71 @@ pub struct Atmosphere {
     /// units: N/A
     pub ground_albedo: Vec3,
 
-    /// An array of scatterers, which describe the atmosphere.
-    ///
-    /// First scatterer is typically Rayleigh (air/CO2)
-    /// Second scatterer is typically Mie (aerosols/dust)
-    /// Third scatterer is typically Ozone (absorption)
-    pub scatterers: [Scatterer; 3],
+    /// An atmosphere has multiple layers, each composed of a medium that interacts with light
+    pub layers: [Medium; 3],
+}
+
+#[derive(Clone, Component, ShaderType)]
+pub struct AtmosphereUniforms {
+    pub bottom_radius: f32,
+    pub top_radius: f32,
+    pub ground_albedo: Vec3,
+    pub layers: [GpuMedium; 3],
+}
+
+impl From<Atmosphere> for AtmosphereUniforms {
+    fn from(atmosphere: Atmosphere) -> Self {
+        Self {
+            bottom_radius: atmosphere.bottom_radius,
+            top_radius: atmosphere.top_radius,
+            ground_albedo: atmosphere.ground_albedo,
+            layers: atmosphere.layers.map(GpuMedium::from),
+        }
+    }
 }
 
 impl Atmosphere {
-    pub const EARTH: Atmosphere = Atmosphere {
+    pub const EARTH: Self = Self {
         bottom_radius: 6_360_000.0,
         top_radius: 6_460_000.0,
-        ground_albedo: Vec3::splat(0.3),
-
-        scatterers: [
+        ground_albedo: Vec3::splat(0.0),
+        layers: [
             // Rayleigh scattering (air molecules)
-            Scatterer {
-                density_profile: DensityProfile {
-                    profile_type: 0,
-                    scale: 1.0 / 8_000.0,
-                    ..DensityProfile::ZERO
-                },
+            Medium {
                 scattering: Vec3::new(5.802e-6, 13.558e-6, 33.100e-6),
                 absorption: Vec3::ZERO,
-                asymmetry: 0.0,
+                density_profile: DensityProfile::Exponential {
+                    scale_height: 8_000.0,
+                },
+                phase_function: PhaseFunction::Rayleigh,
             },
             // Mie scattering (aerosols)
-            Scatterer {
-                density_profile: DensityProfile {
-                    profile_type: 0,
-                    scale: 1.0 / 1_200.0,
-                    ..DensityProfile::ZERO
-                },
+            Medium {
                 scattering: Vec3::splat(3.996e-6),
                 absorption: Vec3::splat(0.444e-6),
-                asymmetry: 0.8,
-            },
-            // Ozone
-            Scatterer {
-                density_profile: DensityProfile {
-                    profile_type: 2,
-                    control_points: [
-                        ControlPoint::new(0.0, 0.022),
-                        ControlPoint::new(8_000.0, 0.0),
-                        ControlPoint::new(21_500.0, 1.0),
-                        ControlPoint::new(39_000.0, 0.034),
-                        ControlPoint::new(40_000.0, 0.0),
-                        ControlPoint::new(45_000.0, 0.0),
-                    ],
-                    num_points: 6,
-                    ..DensityProfile::ZERO
+                density_profile: DensityProfile::Exponential {
+                    scale_height: 1_200.0,
                 },
+                phase_function: PhaseFunction::HenyeyGreenstein(0.8),
+            },
+            // Ozone layer
+            Medium {
                 scattering: Vec3::ZERO,
                 absorption: Vec3::new(0.650e-6, 1.881e-6, 0.085e-6),
-                asymmetry: 0.0,
+                density_profile: DensityProfile::Tent {
+                    center_altitude: 25_000.0,
+                    layer_width: 30_000.0,
+                    exponent: 1.0,
+                },
+                phase_function: PhaseFunction::Rayleigh,
             },
         ],
     };
 
     pub fn with_density_multiplier(mut self, mult: f32) -> Self {
-        for scatterer in self.scatterers.iter_mut() {
-            scatterer.scattering *= mult;
-            scatterer.absorption *= mult;
+        for layer in self.layers.iter_mut() {
+            layer.scattering *= mult;
+            layer.absorption *= mult;
         }
         self
     }
@@ -400,10 +474,10 @@ impl ExtractComponent for Atmosphere {
 
     type QueryFilter = With<Camera3d>;
 
-    type Out = Atmosphere;
+    type Out = AtmosphereUniforms;
 
     fn extract_component(item: QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
-        Some(item.clone())
+        Some(AtmosphereUniforms::from(item.clone()))
     }
 }
 
@@ -503,7 +577,7 @@ impl ExtractComponent for AtmosphereSettings {
 }
 
 fn configure_camera_depth_usages(
-    mut cameras: Query<&mut Camera3d, (Changed<Camera3d>, With<Atmosphere>)>,
+    mut cameras: Query<&mut Camera3d, (Changed<Camera3d>, With<AtmosphereUniforms>)>,
 ) {
     for mut camera in &mut cameras {
         camera.depth_texture_usages.0 |= TextureUsages::TEXTURE_BINDING.bits();

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -410,7 +410,7 @@ impl Atmosphere {
     pub const EARTH: Self = Self {
         bottom_radius: 6_360_000.0,
         top_radius: 6_460_000.0,
-        ground_albedo: Vec3::splat(0.0),
+        ground_albedo: Vec3::splat(0.3),
         layers: [
             // Rayleigh scattering (air molecules)
             Medium {

--- a/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wgsl
@@ -106,7 +106,7 @@ fn sample_multiscattering_dir(r: f32, ray_dir: vec3<f32>, light_dir: vec3<f32>) 
         optical_depth += sample_optical_depth;
 
         let mu_light = dot(light_dir, local_up);
-        let scattering_no_phase = local_atmosphere.rayleigh_scattering + local_atmosphere.mie_scattering;
+        let scattering_no_phase = local_atmosphere.scattering;
 
         let ms = scattering_no_phase;
         let ms_int = (ms - ms * sample_transmittance) / local_atmosphere.extinction;

--- a/crates/bevy_pbr/src/atmosphere/node.rs
+++ b/crates/bevy_pbr/src/atmosphere/node.rs
@@ -15,7 +15,7 @@ use super::{
         AtmosphereBindGroups, AtmosphereLutPipelines, AtmosphereTransformsOffset,
         RenderSkyPipelineId,
     },
-    Atmosphere, AtmosphereSettings,
+    AtmosphereSettings, AtmosphereUniforms,
 };
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash, RenderLabel)]
@@ -31,7 +31,7 @@ impl ViewNode for AtmosphereLutsNode {
     type ViewQuery = (
         Read<AtmosphereSettings>,
         Read<AtmosphereBindGroups>,
-        Read<DynamicUniformIndex<Atmosphere>>,
+        Read<DynamicUniformIndex<AtmosphereUniforms>>,
         Read<DynamicUniformIndex<AtmosphereSettings>>,
         Read<AtmosphereTransformsOffset>,
         Read<ViewUniformOffset>,
@@ -160,7 +160,7 @@ impl ViewNode for RenderSkyNode {
     type ViewQuery = (
         Read<AtmosphereBindGroups>,
         Read<ViewTarget>,
-        Read<DynamicUniformIndex<Atmosphere>>,
+        Read<DynamicUniformIndex<AtmosphereUniforms>>,
         Read<DynamicUniformIndex<AtmosphereSettings>>,
         Read<AtmosphereTransformsOffset>,
         Read<ViewUniformOffset>,

--- a/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
@@ -26,7 +26,7 @@ fn main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     // TODO: this should be user controllable, whether to use per-pixel 
     // raymarching to get volumetric light shafts or the LUT
     // set this to 0.5 to compare with the raymarched reference
-    const raymarch_split = 0.0;
+    const raymarch_split = 0.5;
     if depth == 0.0 {
         let ray_dir_ws = uv_to_ray_direction(in.uv);
         let ray_dir_as = direction_world_to_atmosphere(ray_dir_ws.xyz);
@@ -57,7 +57,7 @@ fn main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
             let r = view_radius();
             let sample_count = mix(1.0, f32(settings.sky_view_lut_samples), clamp(t_max * 0.01, 0.0, 1.0));
             
-            return vec4(raymarch_atmosphere(r, ray_dir_ws.xyz, t_max, sample_count).inscattering, 1.0);
+            return vec4(raymarch_atmosphere(r, ray_dir_ws.xyz, t_max, 40.0).inscattering, 1.0);
         } else {
             return sample_aerial_view_lut(in.uv, depth);
         }

--- a/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/render_sky.wgsl
@@ -1,11 +1,12 @@
 #import bevy_pbr::atmosphere::{
     types::{Atmosphere, AtmosphereSettings},
-    bindings::{atmosphere, view, atmosphere_transforms},
+    bindings::{atmosphere, view, settings, atmosphere_transforms},
     functions::{
         sample_transmittance_lut, sample_sky_view_lut, 
-        direction_world_to_atmosphere, uv_to_ray_direction,
-        uv_to_ndc, sample_aerial_view_lut, view_radius,
-        sample_sun_illuminance,
+        direction_world_to_atmosphere, uv_to_ray_direction, uv_to_ndc,
+        sample_aerial_view_lut, view_radius,
+        sample_sun_illuminance, max_atmosphere_distance,
+        raymarch_atmosphere,
     },
 };
 #import bevy_render::view::View;
@@ -21,6 +22,11 @@
 @fragment
 fn main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let depth = textureLoad(depth_texture, vec2<i32>(in.position.xy), 0);
+
+    // TODO: this should be user controllable, whether to use per-pixel 
+    // raymarching to get volumetric light shafts or the LUT
+    // set this to 0.5 to compare with the raymarched reference
+    const raymarch_split = 0.0;
     if depth == 0.0 {
         let ray_dir_ws = uv_to_ray_direction(in.uv);
         let ray_dir_as = direction_world_to_atmosphere(ray_dir_ws.xyz);
@@ -29,11 +35,31 @@ fn main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         let mu = ray_dir_ws.y;
 
         let transmittance = sample_transmittance_lut(r, mu);
-        let inscattering = sample_sky_view_lut(r, ray_dir_as);
+        
+        var inscattering = vec3(0.0);
+        if (in.uv.x < raymarch_split) {
+            let r = view_radius();
+            let t_max = max_atmosphere_distance(r, ray_dir_ws.y);
+            let sample_count = mix(1.0, f32(settings.sky_view_lut_samples), clamp(t_max * 0.01, 0.0, 1.0));
+            
+            inscattering = raymarch_atmosphere(r, ray_dir_ws.xyz, t_max, sample_count).inscattering;
+        } else {
+            inscattering = sample_sky_view_lut(r, ray_dir_as);
+        }
 
         let sun_illuminance = sample_sun_illuminance(ray_dir_ws.xyz, transmittance);
         return vec4(inscattering + sun_illuminance, (transmittance.r + transmittance.g + transmittance.b) / 3.0);
     } else {
-        return sample_aerial_view_lut(in.uv, depth);
+        if (in.uv.x < raymarch_split) {
+            let ray_dir_ws = uv_to_ray_direction(in.uv);
+            let view_pos = view.view_from_clip * vec4(uv_to_ndc(in.uv), depth, 1.0);
+            let t_max = length(view_pos.xyz / view_pos.w) * settings.scene_units_to_m;
+            let r = view_radius();
+            let sample_count = mix(1.0, f32(settings.sky_view_lut_samples), clamp(t_max * 0.01, 0.0, 1.0));
+            
+            return vec4(raymarch_atmosphere(r, ray_dir_ws.xyz, t_max, sample_count).inscattering, 1.0);
+        } else {
+            return sample_aerial_view_lut(in.uv, depth);
+        }
     }
 }

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -21,7 +21,7 @@ use bevy_render::{
 
 use crate::{GpuLights, LightMeta};
 
-use super::{shaders, Atmosphere, AtmosphereSettings};
+use super::{shaders, AtmosphereSettings, AtmosphereUniforms};
 
 #[derive(Resource)]
 pub(crate) struct AtmosphereBindGroupLayouts {
@@ -45,7 +45,7 @@ impl FromWorld for AtmosphereBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::COMPUTE,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (
                         // transmittance lut storage texture
@@ -64,7 +64,7 @@ impl FromWorld for AtmosphereBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::COMPUTE,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (5, texture_2d(TextureSampleType::Float { filterable: true })), //transmittance lut and sampler
                     (6, sampler(SamplerBindingType::Filtering)),
@@ -85,7 +85,7 @@ impl FromWorld for AtmosphereBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::COMPUTE,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (2, uniform_buffer::<AtmosphereTransform>(true)),
                     (3, uniform_buffer::<ViewUniform>(true)),
@@ -110,7 +110,7 @@ impl FromWorld for AtmosphereBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::COMPUTE,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (3, uniform_buffer::<ViewUniform>(true)),
                     (4, uniform_buffer::<GpuLights>(true)),
@@ -147,7 +147,7 @@ impl FromWorld for RenderSkyBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::FRAGMENT,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (2, uniform_buffer::<AtmosphereTransform>(true)),
                     (3, uniform_buffer::<ViewUniform>(true)),
@@ -176,7 +176,7 @@ impl FromWorld for RenderSkyBindGroupLayouts {
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::FRAGMENT,
                 (
-                    (0, uniform_buffer::<Atmosphere>(true)),
+                    (0, uniform_buffer::<AtmosphereUniforms>(true)),
                     (1, uniform_buffer::<AtmosphereSettings>(true)),
                     (2, uniform_buffer::<AtmosphereTransform>(true)),
                     (3, uniform_buffer::<ViewUniform>(true)),
@@ -384,7 +384,7 @@ impl SpecializedRenderPipeline for RenderSkyBindGroupLayouts {
 }
 
 pub(super) fn queue_render_sky_pipelines(
-    views: Query<(Entity, &Camera, &Msaa), With<Atmosphere>>,
+    views: Query<(Entity, &Camera, &Msaa), With<AtmosphereUniforms>>,
     pipeline_cache: Res<PipelineCache>,
     layouts: Res<RenderSkyBindGroupLayouts>,
     mut specializer: ResMut<SpecializedRenderPipelines<RenderSkyBindGroupLayouts>>,
@@ -412,7 +412,7 @@ pub struct AtmosphereTextures {
 }
 
 pub(super) fn prepare_atmosphere_textures(
-    views: Query<(Entity, &AtmosphereSettings), With<Atmosphere>>,
+    views: Query<(Entity, &AtmosphereSettings), With<AtmosphereUniforms>>,
     render_device: Res<RenderDevice>,
     mut texture_cache: ResMut<TextureCache>,
     mut commands: Commands,
@@ -532,7 +532,7 @@ impl AtmosphereTransformsOffset {
 }
 
 pub(super) fn prepare_atmosphere_transforms(
-    views: Query<(Entity, &ExtractedView), (With<Atmosphere>, With<Camera3d>)>,
+    views: Query<(Entity, &ExtractedView), (With<AtmosphereUniforms>, With<Camera3d>)>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut atmo_uniforms: ResMut<AtmosphereTransforms>,
@@ -587,7 +587,7 @@ pub(crate) struct AtmosphereBindGroups {
 pub(super) fn prepare_atmosphere_bind_groups(
     views: Query<
         (Entity, &AtmosphereTextures, &ViewDepthTexture, &Msaa),
-        (With<Camera3d>, With<Atmosphere>),
+        (With<Camera3d>, With<AtmosphereUniforms>),
     >,
     render_device: Res<RenderDevice>,
     layouts: Res<AtmosphereBindGroupLayouts>,
@@ -596,7 +596,7 @@ pub(super) fn prepare_atmosphere_bind_groups(
     view_uniforms: Res<ViewUniforms>,
     lights_uniforms: Res<LightMeta>,
     atmosphere_transforms: Res<AtmosphereTransforms>,
-    atmosphere_uniforms: Res<ComponentUniforms<Atmosphere>>,
+    atmosphere_uniforms: Res<ComponentUniforms<AtmosphereUniforms>>,
     settings_uniforms: Res<ComponentUniforms<AtmosphereSettings>>,
 
     mut commands: Commands,

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -154,6 +154,8 @@ impl FromWorld for RenderSkyBindGroupLayouts {
                     (4, uniform_buffer::<GpuLights>(true)),
                     (5, texture_2d(TextureSampleType::Float { filterable: true })), //transmittance lut and sampler
                     (6, sampler(SamplerBindingType::Filtering)),
+                    (7, texture_2d(TextureSampleType::Float { filterable: true })), //multiscattering lut and sampler
+                    (8, sampler(SamplerBindingType::Filtering)),
                     (9, texture_2d(TextureSampleType::Float { filterable: true })), //sky view lut and sampler
                     (10, sampler(SamplerBindingType::Filtering)),
                     (
@@ -183,6 +185,8 @@ impl FromWorld for RenderSkyBindGroupLayouts {
                     (4, uniform_buffer::<GpuLights>(true)),
                     (5, texture_2d(TextureSampleType::Float { filterable: true })), //transmittance lut and sampler
                     (6, sampler(SamplerBindingType::Filtering)),
+                    (7, texture_2d(TextureSampleType::Float { filterable: true })), //multiscattering lut and sampler
+                    (8, sampler(SamplerBindingType::Filtering)),
                     (9, texture_2d(TextureSampleType::Float { filterable: true })), //sky view lut and sampler
                     (10, sampler(SamplerBindingType::Filtering)),
                     (
@@ -699,6 +703,8 @@ pub(super) fn prepare_atmosphere_bind_groups(
                 (4, lights_binding.clone()),
                 (5, &textures.transmittance_lut.default_view),
                 (6, &samplers.transmittance_lut),
+                (7, &textures.multiscattering_lut.default_view),
+                (8, &samplers.multiscattering_lut),
                 (9, &textures.sky_view_lut.default_view),
                 (10, &samplers.sky_view_lut),
                 (11, &textures.aerial_view_lut.default_view),

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -371,7 +371,7 @@ impl SpecializedRenderPipeline for RenderSkyBindGroupLayouts {
                     blend: Some(BlendState {
                         color: BlendComponent {
                             src_factor: BlendFactor::One,
-                            dst_factor: BlendFactor::SrcAlpha,
+                            dst_factor: BlendFactor::Zero,
                             operation: BlendOperation::Add,
                         },
                         alpha: BlendComponent {

--- a/crates/bevy_pbr/src/atmosphere/sky_view_lut.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/sky_view_lut.wgsl
@@ -2,12 +2,11 @@
     mesh_view_types::Lights,
     atmosphere::{
         types::{Atmosphere, AtmosphereSettings},
-        bindings::{atmosphere, view, settings},
+        bindings::{atmosphere, view, settings, lights},
         functions::{
-            sample_atmosphere, get_local_up, AtmosphereSample,
-            sample_local_inscattering, get_local_r, view_radius,
-            max_atmosphere_distance, direction_atmosphere_to_world,
+            view_radius, max_atmosphere_distance, direction_atmosphere_to_world,
             sky_view_lut_uv_to_zenith_azimuth, zenith_azimuth_to_ray_dir,
+            raymarch_atmosphere,
         },
     }
 }
@@ -31,48 +30,9 @@ fn main(@builtin(global_invocation_id) idx: vec3<u32>) {
     let ray_dir_as = zenith_azimuth_to_ray_dir(zenith_azimuth.x, zenith_azimuth.y);
     let ray_dir_ws = direction_atmosphere_to_world(ray_dir_as);
 
-    let mu = ray_dir_ws.y;
-    let t_max = max_atmosphere_distance(r, mu);
-
-    // Raymarch with quadratic distribution
+    let t_max = max_atmosphere_distance(r, ray_dir_ws.y);
     let sample_count = mix(1.0, f32(settings.sky_view_lut_samples), clamp(t_max * 0.01, 0.0, 1.0));
-    let sample_count_floor = floor(sample_count);
-    let t_max_floor = t_max * sample_count_floor / sample_count;
-    var total_inscattering = vec3(0.0);
-    var throughput = vec3(1.0);
-    for (var s = 0.0; s < sample_count; s += 1.0) {
-        // Use quadratic distribution like reference
-        var t0 = (s / sample_count_floor);
-        var t1 = ((s + 1.0) / sample_count_floor);
-        t0 = t0 * t0;
-        t1 = t1 * t1;
-        t1 = select(t_max_floor * t1, t_max, t1 > 1.0);
-        let t_i = t_max_floor * t0 + (t1 - t_max_floor * t0) * 0.3;
-        let dt_i = t1 - t_max_floor * t0;
-
-        let local_r = get_local_r(r, mu, t_i);
-        let local_up = get_local_up(r, t_i, ray_dir_ws);
-        let local_atmosphere = sample_atmosphere(local_r);
-
-        let sample_optical_depth = local_atmosphere.extinction * dt_i;
-        let sample_transmittance = exp(-sample_optical_depth);
-
-        let inscattering = sample_local_inscattering(
-            local_atmosphere,
-            ray_dir_ws,
-            local_r,
-            local_up
-        );
-
-        // Analytical integration of the single scattering term in the radiance transfer equation
-        let s_int = (inscattering - inscattering * sample_transmittance) / local_atmosphere.extinction;
-        total_inscattering += throughput * s_int;
-
-        throughput *= sample_transmittance;
-        if all(throughput < vec3(0.001)) {
-            break;
-        }
-    }
-
-    textureStore(sky_view_lut_out, idx.xy, vec4(total_inscattering, 1.0));
+    
+    let result = raymarch_atmosphere(r, ray_dir_ws, t_max, sample_count);
+    textureStore(sky_view_lut_out, idx.xy, vec4(result.inscattering, 1.0));
 }

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -1,33 +1,20 @@
 #define_import_path bevy_pbr::atmosphere::types
 
-struct ControlPoint {
-    altitude_density: vec4<f32>,
-}
-
-struct DensityProfile {
-    profile_type: u32,
-    scale: f32,
-    scale_high: f32,
-    split_altitude: f32,
-    control_points: array<ControlPoint, 6>,
-    num_points: u32,
-}
-
-struct Scatterer {
-    density_profile: DensityProfile,
-    asymmetry: f32,
+struct GpuMedium {
     scattering: vec3<f32>,
     absorption: vec3<f32>,
+    density_params: vec4<f32>,
+    phase_params: vec4<f32>,
 }
 
-struct Atmosphere {
+struct AtmosphereUniforms {
     // Planet properties
     bottom_radius: f32,
     top_radius: f32,
     ground_albedo: vec3<f32>,
 
-    // Array of scatterers (fixed size 3)
-    scatterers: array<Scatterer, 3>,
+    // Array of layers (fixed size 3)
+    layers: array<GpuMedium, 3>,
 }
 
 struct AtmosphereSettings {

--- a/crates/bevy_pbr/src/atmosphere/types.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/types.wgsl
@@ -1,25 +1,33 @@
 #define_import_path bevy_pbr::atmosphere::types
 
+struct ControlPoint {
+    altitude_density: vec4<f32>,
+}
+
+struct DensityProfile {
+    profile_type: u32,
+    scale: f32,
+    scale_high: f32,
+    split_altitude: f32,
+    control_points: array<ControlPoint, 6>,
+    num_points: u32,
+}
+
+struct Scatterer {
+    density_profile: DensityProfile,
+    asymmetry: f32,
+    scattering: vec3<f32>,
+    absorption: vec3<f32>,
+}
+
 struct Atmosphere {
-    // Radius of the planet
-    bottom_radius: f32, // units: m
-
-    // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
-    top_radius: f32, // units: m
-
+    // Planet properties
+    bottom_radius: f32,
+    top_radius: f32,
     ground_albedo: vec3<f32>,
 
-    rayleigh_density_exp_scale: f32,
-    rayleigh_scattering: vec3<f32>,
-
-    mie_density_exp_scale: f32,
-    mie_scattering: f32, // units: m^-1
-    mie_absorption: f32, // units: m^-1
-    mie_asymmetry: f32, // the "asymmetry" value of the phase function, unitless. Domain: (-1, 1)
-
-    ozone_layer_altitude: f32, // units: m
-    ozone_layer_width: f32, // units: m
-    ozone_absorption: vec3<f32>, // ozone absorption. units: m^-1
+    // Array of scatterers (fixed size 3)
+    scatterers: array<Scatterer, 3>,
 }
 
 struct AtmosphereSettings {

--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -105,7 +105,9 @@ fn project_onto(lhs: vec3<f32>, rhs: vec3<f32>) -> vec3<f32> {
 // accuracy can be sacrificed for greater sample count.
 
 fn fast_sqrt(x: f32) -> f32 {
-    return bitcast<f32>(0x1fbd1df5 + (bitcast<i32>(x) >> 1u));
+    let n = bitcast<f32>(0x1fbd1df5 + (bitcast<i32>(x) >> 1u));
+    // One Newton's method iteration for better precision
+    return 0.5 * (n + x / n);
 }
 
 // Slightly less accurate than fast_acos_4, but much simpler.

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -18,6 +18,7 @@ fn main() {
 }
 
 fn setup_camera_fog(mut commands: Commands) {
+    let offset = 0.0;
     commands.spawn((
         Camera3d::default(),
         // HDR is required for atmospheric scattering to be properly applied to the scene
@@ -25,7 +26,7 @@ fn setup_camera_fog(mut commands: Commands) {
             hdr: true,
             ..default()
         },
-        Transform::from_xyz(-1.2, 0.15, 0.0).looking_at(Vec3::Y * 0.1, Vec3::Y),
+        Transform::from_xyz(-1.2, 0.15 + offset, 0.0).looking_at(Vec3::Y * offset, Vec3::Y),
         // This is the component that enables atmospheric scattering for a camera
         Atmosphere::EARTH,
         // The scene is in units of 10km, so we need to scale up the
@@ -78,7 +79,7 @@ fn setup_terrain_scene(
             illuminance: lux::RAW_SUNLIGHT,
             ..default()
         },
-        Transform::from_xyz(1.0, -0.4, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Transform::from_xyz(1.0, 0.4, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
         cascade_shadow_config,
     ));
 
@@ -108,18 +109,34 @@ fn setup_terrain_scene(
     ));
 
     // Terrain
+    // commands.spawn((
+    //     Terrain,
+    //     SceneRoot(
+    //         asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/terrain/terrain.glb")),
+    //     ),
+    //     Transform::from_xyz(-1.0, 0.0, -0.5)
+    //         .with_scale(Vec3::splat(0.5))
+    //         .with_rotation(Quat::from_rotation_y(PI / 2.0)),
+    // ));
+
+    let plane_mesh = meshes.add(Mesh::from(Plane3d {
+        half_size: Vec2::splat(20.0),
+        normal: Dir3::Y,
+    }));
+
+    // Large plane
     commands.spawn((
-        Terrain,
-        SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/terrain/terrain.glb")),
-        ),
-        Transform::from_xyz(-1.0, 0.0, -0.5)
-            .with_scale(Vec3::splat(0.5))
-            .with_rotation(Quat::from_rotation_y(PI / 2.0)),
+        Mesh3d(plane_mesh.clone()),
+        MeshMaterial3d(materials.add(StandardMaterial {
+            base_color: Color::WHITE,
+            metallic: 0.0,
+            perceptual_roughness: 1.0,
+            ..default()
+        })),
     ));
 }
 
 fn dynamic_scene(mut suns: Query<&mut Transform, With<DirectionalLight>>, time: Res<Time>) {
-    suns.iter_mut()
-        .for_each(|mut tf| tf.rotate_x(-time.delta_secs() * PI / 10.0));
+    // suns.iter_mut()
+    //     .for_each(|mut tf| tf.rotate_x(-time.delta_secs() * PI / 10.0));
 }

--- a/examples/3d/atmosphere.rs
+++ b/examples/3d/atmosphere.rs
@@ -32,7 +32,7 @@ fn setup_camera_fog(mut commands: Commands) {
         // aerial view lut distance and set the scene scale accordingly.
         // Most usages of this feature will not need to adjust this.
         AtmosphereSettings {
-            aerial_view_lut_max_distance: 3.2e5,
+            aerial_view_lut_max_distance: 3.2e4,
             scene_units_to_m: 1e+4,
             ..Default::default()
         },


### PR DESCRIPTION
# Objective

Sharing for early feedback. The goal is to generalize the atmospheric model uniform to include a list of layers of type `Medium`, with ability to specify a custom `DensityProfile` and `PhaseFunction`.

## Solution

Included more structs in the WGSL types, as well as the main `mod.rs` that describe the atmosphere in a more generic way.

The current parameterization is Inspired by a repo called [CalcMySky](https://github.com/10110111/CalcMySky) that has an physically accurate implementation of the Martian atmosphere.

Example definition for Mars (not accurate values, just placeholders):
```rust
pub const MARS: Self = Self {
    bottom_radius: 3_389_500.0,
    top_radius: 3_509_500.0,
    ground_albedo: Vec3::splat(0.3),
    layers: [
        // CO2 (primary atmospheric component on Mars)
        Medium {
            scattering: Vec3::new(7.0e-6, 16.3e-6, 39.7e-6),
            absorption: Vec3::ZERO,
            density_profile: DensityProfile::SplitExponential {
                scale_height_lower: 7752.0,  // 1/0.129e-3
                center_altitude: 39_652.4,
                scale_height_upper: 11111.0, // 1/0.09e-3
            },
            phase_function: PhaseFunction::Rayleigh,
        },
        // Dust (Martian aerosols)
        Medium {
            scattering: Vec3::splat(5.0e-6),
            absorption: Vec3::splat(2.0e-6),
            density_profile: DensityProfile::Exponential {
                scale_height: 10_800.0,
            },
            phase_function: PhaseFunction::HenyeyGreenstein(0.64),
        },
        // Empty third layer (Mars has no ozone layer)
        Medium::EMTPY,
    ],
};
```

## Testing and next steps

Atmosphere renders as normal / as before. Will continue to expand this PR to include the Martian atmosphere derived from real physical data and attach to the showcase.

At the present moment I am not sure what is the best way to approach this, or to approach custom phase functions.

Maybe we should have a list of hardcoded density profiles in the shader that the user could choose from? Maybe some of these physical parameters should be directly hardcoded into the shader exposing only simple controls like atmosphere scale height and density to the user. This PR is meant to start this discussion.

This PR is to also start tinkering and experimenting about how this could be used with cloud rendering, which may require a custom pass or render graph / nodes, or with existing volumetrics code and ECS. 